### PR TITLE
Handler type already excludes null.

### DIFF
--- a/lib/src/mixin_state.dart
+++ b/lib/src/mixin_state.dart
@@ -492,7 +492,7 @@ class _MixinState {
     watch.lastValue = AsyncSnapshot<R?>.withData(
         ConnectionState.waiting, _initialValue ?? initialValueProvider?.call());
     if (executeImmediately) {
-      handler!(_element!, watch.lastValue!, watch.dispose);
+      handler(_element!, watch.lastValue!, watch.dispose);
     }
 
     return watch.lastValue!;


### PR DESCRIPTION
Fixes this warning:

```
lib/src/mixin_state.dart:495:7: Warning: Operand of null-aware operation '!' has type 'void Function(BuildContext, AsyncSnapshot<R?>, void Function())' which excludes null.
 - 'BuildContext' is from 'package:flutter/src/widgets/framework.dart' ('/D:/Development/flutter/packages/flutter/lib/src/widgets/framework.dart').
 - 'AsyncSnapshot' is from 'package:flutter/src/widgets/async.dart' ('/D:/Development/flutter/packages/flutter/lib/src/widgets/async.dart').
      handler!(_element!, watch.lastValue!, watch.dispose);
```